### PR TITLE
Combine all basic markdown options into one USE_MARKDOWN

### DIFF
--- a/gulp/res/css/style.css
+++ b/gulp/res/css/style.css
@@ -512,18 +512,9 @@ p {
 	color: var(--pinktext-color);
 }
 
-@keyframes steady-glow {
-  0%, 100% {
-    text-shadow: 0 0 10px #006400, 0 0 20px #006400, 0 0 30px #006400;
-  }
-  50% {
-    text-shadow: 0 0 20px #006400, 0 0 60px #006400, 0 0 40px #006400;
-  }
-}
-
 .glowtext {
-  color: #008000; /* Darker green */
-  animation: steady-glow 2s infinite ease-in-out;
+	color: #008000; /* Darker green */
+    text-shadow: 0 0 10px #006400, 0 0 20px #006400, 0 0 30px #006400;
 }
 
 .embimg {

--- a/gulp/res/css/style.css
+++ b/gulp/res/css/style.css
@@ -512,6 +512,20 @@ p {
 	color: var(--pinktext-color);
 }
 
+@keyframes steady-glow {
+  0%, 100% {
+    text-shadow: 0 0 10px #006400, 0 0 20px #006400, 0 0 30px #006400;
+  }
+  50% {
+    text-shadow: 0 0 20px #006400, 0 0 60px #006400, 0 0 40px #006400;
+  }
+}
+
+.glowtext {
+  color: #008000; /* Darker green */
+  animation: steady-glow 2s infinite ease-in-out;
+}
+
 .embimg {
 	max-width:100%;
 	max-height:40vh

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -220,22 +220,7 @@ async function wipe() {
 
 	const ANON = new Permission();
 	ANON.setAll([
-		Permissions.USE_MARKDOWN_PINKTEXT,
-		Permissions.USE_MARKDOWN_GREENTEXT,
-		Permissions.USE_MARKDOWN_BOLD,
-		Permissions.USE_MARKDOWN_UNDERLINE,
-		Permissions.USE_MARKDOWN_STRIKETHROUGH,
-		Permissions.USE_MARKDOWN_TITLE,
-		Permissions.USE_MARKDOWN_ITALIC,
-		Permissions.USE_MARKDOWN_SPOILER,
-		Permissions.USE_MARKDOWN_MONO,
-		Permissions.USE_MARKDOWN_CODE,
-		Permissions.USE_MARKDOWN_DETECTED,
-		Permissions.USE_MARKDOWN_LINK,
-		Permissions.USE_MARKDOWN_DICE,
-		Permissions.USE_MARKDOWN_FORTUNE,
-		Permissions.CREATE_BOARD,
-		Permissions.CREATE_ACCOUNT,
+		Permissions.USE_MARKDOWN,
 	]);
 
 	const BOARD_STAFF_DEFAULTS = new Permission(ANON.base64);
@@ -246,13 +231,6 @@ async function wipe() {
 	]);
 
 	const BOARD_STAFF = new Permission(BOARD_STAFF_DEFAULTS.base64);
-	BOARD_STAFF.setAll([
-		Permissions.MANAGE_BOARD_OWNER,
-		Permissions.MANAGE_BOARD_STAFF,
-		Permissions.MANAGE_BOARD_CUSTOMISATION,
-		Permissions.MANAGE_BOARD_SETTINGS,
-		Permissions.USE_MARKDOWN_IMAGE,
-	]);
 
 	const BOARD_OWNER_DEFAULTS = new Permission(BOARD_STAFF.base64);
 	BOARD_OWNER_DEFAULTS.setAll([
@@ -260,17 +238,9 @@ async function wipe() {
 		Permissions.MANAGE_BOARD_STAFF,
 		Permissions.MANAGE_BOARD_CUSTOMISATION,
 		Permissions.MANAGE_BOARD_SETTINGS,
-		Permissions.USE_MARKDOWN_IMAGE,
 	]);
 
-	const BOARD_OWNER = new Permission(BOARD_STAFF.base64);
-	BOARD_OWNER.setAll([
-		Permissions.MANAGE_BOARD_OWNER,
-		Permissions.MANAGE_BOARD_STAFF,
-		Permissions.MANAGE_BOARD_CUSTOMISATION,
-		Permissions.MANAGE_BOARD_SETTINGS,
-		Permissions.USE_MARKDOWN_IMAGE,
-	]);
+	const BOARD_OWNER = new Permission(BOARD_OWNER_DEFAULTS.base64);
 
 	const GLOBAL_STAFF = new Permission(BOARD_OWNER.base64);
 	GLOBAL_STAFF.setAll([
@@ -285,14 +255,15 @@ async function wipe() {
 		Permissions.BYPASS_BANS,
 		Permissions.BYPASS_SPAMCHECK,
 		Permissions.BYPASS_RATELIMITS,
-		Permissions.USE_MARKDOWN_IMAGE,
 	]);
 
 	const ADMIN = new Permission(GLOBAL_STAFF.base64);
 	ADMIN.setAll([
+		Permissions.CREATE_BOARD,
+		Permissions.CREATE_ACCOUNT,
 		Permissions.MANAGE_GLOBAL_ACCOUNTS,
 		Permissions.MANAGE_GLOBAL_ROLES,
-		Permissions.VIEW_RAW_IP,
+		Permissions.USE_MARKDOWN_IMAGE,
 	]);
 
 	const ROOT = new Permission();

--- a/lib/permission/permission.test.js
+++ b/lib/permission/permission.test.js
@@ -7,17 +7,9 @@ describe('testing permissions', () => {
 
 	const ANON = new Permission();
 	ANON.setAll([
-		Permissions.USE_MARKDOWN_PINKTEXT, Permissions.USE_MARKDOWN_GREENTEXT, Permissions.USE_MARKDOWN_BOLD,
-		Permissions.USE_MARKDOWN_UNDERLINE, Permissions.USE_MARKDOWN_STRIKETHROUGH, Permissions.USE_MARKDOWN_TITLE,
-		Permissions.USE_MARKDOWN_ITALIC, Permissions.USE_MARKDOWN_SPOILER, Permissions.USE_MARKDOWN_MONO,
-		Permissions.USE_MARKDOWN_CODE, Permissions.USE_MARKDOWN_DETECTED, Permissions.USE_MARKDOWN_LINK,
-		Permissions.USE_MARKDOWN_DICE, Permissions.USE_MARKDOWN_FORTUNE, Permissions.CREATE_BOARD,
-		Permissions.CREATE_ACCOUNT
+		Permissions.USE_MARKDOWN,
 	]);
 
-	test('test a permission they have = true', () => {
-		expect(ANON.get(Permissions.CREATE_ACCOUNT)).toBe(true);
-	});
 
 	test('test a permission they dont have = false', () => {
 		expect(ANON.get(Permissions.ROOT)).toBe(false);
@@ -30,7 +22,7 @@ describe('testing permissions', () => {
 	const BOARD_OWNER = new Permission(BOARD_STAFF.base64);
 	BOARD_OWNER.setAll([
 		Permissions.MANAGE_BOARD_OWNER, Permissions.MANAGE_BOARD_STAFF, Permissions.MANAGE_BOARD_CUSTOMISATION,
-		Permissions.MANAGE_BOARD_SETTINGS, Permissions.USE_MARKDOWN_IMAGE
+		Permissions.MANAGE_BOARD_SETTINGS
 	]);
 
 	test('BO has all board perms', () => {
@@ -41,11 +33,13 @@ describe('testing permissions', () => {
 	GLOBAL_STAFF.setAll([
 		Permissions.MANAGE_GLOBAL_GENERAL, Permissions.MANAGE_GLOBAL_BANS, Permissions.MANAGE_GLOBAL_LOGS, Permissions.MANAGE_GLOBAL_NEWS,
 		Permissions.MANAGE_GLOBAL_BOARDS, Permissions.MANAGE_GLOBAL_SETTINGS, Permissions.MANAGE_BOARD_OWNER, Permissions.BYPASS_FILTERS,
-		Permissions.BYPASS_BANS, Permissions.BYPASS_SPAMCHECK, Permissions.BYPASS_RATELIMITS, Permissions.BYPASS_DNBSBL, Permissions.USE_MARKDOWN_IMAGE
+		Permissions.BYPASS_BANS, Permissions.BYPASS_SPAMCHECK, Permissions.BYPASS_RATELIMITS, Permissions.BYPASS_DNBSBL,
 	]);
 	const ADMIN = new Permission(GLOBAL_STAFF.base64);
 	ADMIN.setAll([
-		Permissions.MANAGE_GLOBAL_ACCOUNTS, Permissions.MANAGE_GLOBAL_ROLES, Permissions.VIEW_RAW_IP,
+		Permissions.MANAGE_GLOBAL_ACCOUNTS, Permissions.MANAGE_GLOBAL_ROLES, Permissions.VIEW_RAW_IP, 
+		Permissions.CREATE_ACCOUNT, Permissions.CREATE_BOARD, 
+		Permissions.USE_MARKDOWN_IMAGE,
 	]);
 	const ROOT = new Permission();
 	ROOT.setAll(Permission.allPermissions);

--- a/lib/permission/permissions.js
+++ b/lib/permission/permissions.js
@@ -37,20 +37,7 @@ const Permissions = Object.seal(Object.freeze(Object.preventExtensions({
 
 	VIEW_BOARD_GLOBAL_BANS: 30,
 
-	USE_MARKDOWN_PINKTEXT: 35,
-	USE_MARKDOWN_GREENTEXT: 36,
-	USE_MARKDOWN_BOLD: 37,
-	USE_MARKDOWN_UNDERLINE: 38,
-	USE_MARKDOWN_STRIKETHROUGH: 39,
-	USE_MARKDOWN_TITLE: 40,
-	USE_MARKDOWN_ITALIC: 41,
-	USE_MARKDOWN_SPOILER: 42,
-	USE_MARKDOWN_MONO: 43,
-	USE_MARKDOWN_CODE: 44,
-	USE_MARKDOWN_DETECTED: 45,
-	USE_MARKDOWN_LINK: 46,
-	USE_MARKDOWN_DICE: 47,
-	USE_MARKDOWN_FORTUNE: 48,
+	USE_MARKDOWN: 35,
 	USE_MARKDOWN_IMAGE: 49,
 
 })));
@@ -90,22 +77,8 @@ const Metadata = Object.seal(Object.freeze(Object.preventExtensions({
 	[Permissions.MANAGE_BOARD_STAFF]: { label: 'Staff', desc: 'Access to staff management, and ability to add or remove permissions from others. Use with caution!', parents: [Permissions.MANAGE_BOARD_OWNER] },
 	[Permissions.VIEW_BOARD_GLOBAL_BANS]: { label: 'View Board Global Bans', desc: 'Ability to view global bans on board modlog pages if the banned post originated from that board.', parents: [Permissions.ROOT] },
 
-	[Permissions.USE_MARKDOWN_PINKTEXT]: { title: 'Post styling', label: 'Pinktext', desc: 'Use pinktext' },
-	[Permissions.USE_MARKDOWN_GREENTEXT]: { label: 'Greentext', desc: 'Use greentext' },
-	[Permissions.USE_MARKDOWN_BOLD]: { label: 'Bold', desc: 'Use bold' },
-	[Permissions.USE_MARKDOWN_UNDERLINE]: { label: 'Underline', desc: 'Use underline' },
-	[Permissions.USE_MARKDOWN_STRIKETHROUGH]: { label: 'Strikethrough', desc: 'Use strikethrough' },
-	[Permissions.USE_MARKDOWN_TITLE]: { label: 'Title', desc: 'Use titles' },
-	[Permissions.USE_MARKDOWN_ITALIC]: { label: 'Italic', desc: 'Use italics' },
-	[Permissions.USE_MARKDOWN_SPOILER]: { label: 'Spoiler', desc: 'Use spoilers' },
-	[Permissions.USE_MARKDOWN_MONO]: { label: 'Inline Monospace', desc: 'Use inline monospace' },
-	[Permissions.USE_MARKDOWN_CODE]: { label: 'Code Block', desc: 'Use code blocks' },
-	[Permissions.USE_MARKDOWN_DETECTED]: { label: 'Detected', desc: 'Use detected' },
-	[Permissions.USE_MARKDOWN_LINK]: { label: 'Links', desc: 'Make links clickable' },
-	[Permissions.USE_MARKDOWN_DICE]: { label: 'Dice Roll', desc: 'Use dice rolls' },
-	[Permissions.USE_MARKDOWN_FORTUNE]: { label: 'Fortune', desc: 'Use fortunes' },
+	[Permissions.USE_MARKDOWN]: { title: 'Post styling', label: 'Post styling', desc: 'Use post styling' },
 	[Permissions.USE_MARKDOWN_IMAGE]: { label: 'Embed Images', desc: 'Embed images', parents: [Permissions.MANAGE_BOARD_OWNER] }, //TODO: add a new permission bit to manage each board inherited perm and use them as additional parents
-
 })));
 
 module.exports = {

--- a/lib/post/markdown/handler/fortune.js
+++ b/lib/post/markdown/handler/fortune.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fortunes = ['example1', 'example2', 'example3'];
+const fortunes = ['Fluffy encounter!', 'Scalie encounter!', 'Featheary encounter!'];
 
 module.exports = {
 
@@ -10,7 +10,7 @@ module.exports = {
 
 	markdown: () => {
 		const randomFortune = fortunes[Math.floor(Math.random()*fortunes.length)];
-		return `<span class='title'>${randomFortune}</span>`;
+		return `<span class='title'>Your fortune: ${randomFortune}</span>`;
 	},
 
 };

--- a/lib/post/markdown/markdown.js
+++ b/lib/post/markdown/markdown.js
@@ -2,6 +2,7 @@
 
 const greentextRegex = /^&gt;((?!&gt;\d+|&gt;&gt;&#x2F;\w+(&#x2F;\d*)?|&gt;&gt;#&#x2F;).*)/gm
 	, pinktextRegex = /^&lt;(.+)/gm
+	, glowtextRegex = /%%(.+?)%%/gm
 	, boldRegex = /&#39;&#39;(.+?)&#39;&#39;/gm
 	, titleRegex = /&#x3D;&#x3D;(.+?)&#x3D;&#x3D;/gm
 	, monoRegex = /&#x60;(.+?)&#x60;/gm
@@ -31,20 +32,21 @@ let replacements = [];
 
 const updateMarkdownPerms = () => {
 	replacements = [
-		{ permission: Permissions.USE_MARKDOWN_PINKTEXT, regex: pinktextRegex, cb: (permissions, match, pinktext) => `<span class='pinktext'>&lt;${pinktext}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_GREENTEXT, regex: greentextRegex, cb: (permissions, match, greentext) => `<span class='greentext'>&gt;${greentext}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_BOLD, regex: boldRegex, cb: (permissions, match, bold) => `<span class='bold'>${bold}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_UNDERLINE, regex: underlineRegex, cb: (permissions, match, underline) => `<span class='underline'>${underline}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_STRIKETHROUGH, regex: strikeRegex, cb: (permissions, match, strike) => `<span class='strike'>${strike}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_TITLE, regex: titleRegex, cb: (permissions, match, title) => `<span class='title'>${title}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_ITALIC, regex: italicRegex, cb: (permissions, match, italic) => `<span class='em'>${italic}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_SPOILER, regex: spoilerRegex, cb: (permissions, match, spoiler) => `<span class='spoiler'>${spoiler}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_MONO, regex: monoRegex, cb: (permissions, match, mono) => `<span class='mono'>${mono}</span>` },
-		{ permission: Permissions.USE_MARKDOWN_DETECTED, regex: detectedRegex, cb: (permissions, match, detected) => `<span class='detected'>&lpar;&lpar;&lpar; ${detected} &rpar;&rpar;&rpar;</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: glowtextRegex, cb: (permissions, match, glowtext) => `<span class='glowtext'>${glowtext}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: pinktextRegex, cb: (permissions, match, pinktext) => `<span class='pinktext'>&lt;${pinktext}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: greentextRegex, cb: (permissions, match, greentext) => `<span class='greentext'>&gt;${greentext}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: boldRegex, cb: (permissions, match, bold) => `<span class='bold'>${bold}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: underlineRegex, cb: (permissions, match, underline) => `<span class='underline'>${underline}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: strikeRegex, cb: (permissions, match, strike) => `<span class='strike'>${strike}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: titleRegex, cb: (permissions, match, title) => `<span class='title'>${title}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: italicRegex, cb: (permissions, match, italic) => `<span class='em'>${italic}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: spoilerRegex, cb: (permissions, match, spoiler) => `<span class='spoiler'>${spoiler}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: monoRegex, cb: (permissions, match, mono) => `<span class='mono'>${mono}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: detectedRegex, cb: (permissions, match, detected) => `<span class='detected'>&lpar;&lpar;&lpar; ${detected} &rpar;&rpar;&rpar;</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: linkRegex, cb: linkmatch },
+		{ permission: Permissions.USE_MARKDOWN, regex: diceroll.regexMarkdown, cb: diceroll.markdown },
+		{ permission: Permissions.USE_MARKDOWN, regex: fortune.regex, cb: fortune.markdown },
 		{ permission: Permissions.USE_MARKDOWN_IMAGE, regex: imageRegex, cb: (permissions, match, altText, imageSrc) => `<img class='embimg' title='${altText}' alt='${altText}' src='${imageSrc}' />` },
-		{ permission: Permissions.USE_MARKDOWN_LINK, regex: linkRegex, cb: linkmatch },
-		{ permission: Permissions.USE_MARKDOWN_DICE, regex: diceroll.regexMarkdown, cb: diceroll.markdown },
-		{ permission: Permissions.USE_MARKDOWN_FORTUNE, regex: fortune.regex, cb: fortune.markdown },
 	];
 };
 

--- a/migrations/1.7.3.js
+++ b/migrations/1.7.3.js
@@ -1,0 +1,82 @@
+'use strict';
+
+//Note: if I drastically change permissions lib in future this might break. hmmmmm......
+const { Permissions } = require(__dirname+'/../lib/permission/permissions.js')
+	, Permission = require(__dirname+'/../lib/permission/permission.js')
+	, { Binary } = require('mongodb');
+
+module.exports = async(db, redis) => {
+
+	const ANON = new Permission();
+	ANON.setAll([
+		Permissions.USE_MARKDOWN,
+	]);
+
+	const BOARD_STAFF_DEFAULTS = new Permission(ANON.base64);
+	BOARD_STAFF_DEFAULTS.setAll([
+		Permissions.MANAGE_BOARD_GENERAL,
+		Permissions.MANAGE_BOARD_BANS,
+		Permissions.MANAGE_BOARD_LOGS,
+	]);
+
+	const BOARD_STAFF = new Permission(BOARD_STAFF_DEFAULTS.base64);
+
+	const BOARD_OWNER_DEFAULTS = new Permission(BOARD_STAFF.base64);
+	BOARD_OWNER_DEFAULTS.setAll([
+		Permissions.MANAGE_BOARD_OWNER,
+		Permissions.MANAGE_BOARD_STAFF,
+		Permissions.MANAGE_BOARD_CUSTOMISATION,
+		Permissions.MANAGE_BOARD_SETTINGS,
+	]);
+
+	const BOARD_OWNER = new Permission(BOARD_OWNER_DEFAULTS.base64);
+
+	const GLOBAL_STAFF = new Permission(BOARD_OWNER.base64);
+	GLOBAL_STAFF.setAll([
+		Permissions.MANAGE_GLOBAL_GENERAL,
+		Permissions.MANAGE_GLOBAL_BANS,
+		Permissions.MANAGE_GLOBAL_LOGS,
+		Permissions.MANAGE_GLOBAL_NEWS,
+		Permissions.MANAGE_GLOBAL_BOARDS,
+		Permissions.MANAGE_GLOBAL_SETTINGS,
+		Permissions.MANAGE_BOARD_OWNER,
+		Permissions.BYPASS_FILTERS,
+		Permissions.BYPASS_BANS,
+		Permissions.BYPASS_SPAMCHECK,
+		Permissions.BYPASS_RATELIMITS,
+	]);
+
+	const ADMIN = new Permission(GLOBAL_STAFF.base64);
+	ADMIN.setAll([
+		Permissions.CREATE_BOARD,
+		Permissions.CREATE_ACCOUNT,
+		Permissions.MANAGE_GLOBAL_ACCOUNTS,
+		Permissions.MANAGE_GLOBAL_ROLES,
+		Permissions.USE_MARKDOWN_IMAGE,
+	]);
+
+	const ROOT = new Permission();
+	ROOT.setAll(Permission.allPermissions);
+
+	console.log('Removing unnecessary unique index on roles db');
+	await db.collection('roles').deleteMany({});
+
+	console.log('Adding missing defaults "roles" to db');
+	await db.collection('roles').insertMany([
+		{ name: 'ANON', permissions: Binary(ANON.array) },
+		{ name: 'BOARD_STAFF', permissions: Binary(BOARD_STAFF.array) },
+		{ name: 'BOARD_OWNER', permissions: Binary(BOARD_OWNER.array) },
+		{ name: 'BOARD_STAFF_DEFAULTS', permissions: Binary(BOARD_STAFF_DEFAULTS.array) },
+		{ name: 'BOARD_OWNER_DEFAULTS', permissions: Binary(BOARD_OWNER_DEFAULTS.array) },
+		{ name: 'GLOBAL_STAFF', permissions: Binary(GLOBAL_STAFF.array) },
+		{ name: 'ADMIN', permissions: Binary(ADMIN.array) },
+		{ name: 'ROOT', permissions: Binary(ROOT.array) },
+	]);
+
+	console.log('Clearing globalsettings cache');
+	await redis.deletePattern('globalsettings');
+	console.log('Clearing sessions and users cache');
+	await redis.deletePattern('users:*');
+	await redis.deletePattern('sess:*');
+
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jschan",
   "version": "1.7.0",
-  "migrateVersion": "1.7.2",
+  "migrateVersion": "1.7.3",
   "description": "",
   "main": "server.js",
   "dependencies": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -307,20 +307,7 @@ module.exports = () => describe('login and create test board', () => {
 			CREATE_BOARD: '2',
 			CREATE_ACCOUNT: '3',
 			BYPASS_CAPTCHA: '8',
-			USE_MARKDOWN_PINKTEXT: '35',
-			USE_MARKDOWN_GREENTEXT: '36',
-			USE_MARKDOWN_BOLD: '37',
-			USE_MARKDOWN_UNDERLINE: '38',
-			USE_MARKDOWN_STRIKETHROUGH: '39',
-			USE_MARKDOWN_TITLE: '40',
-			USE_MARKDOWN_ITALIC: '41',
-			USE_MARKDOWN_SPOILER: '42',
-			USE_MARKDOWN_MONO: '43',
-			USE_MARKDOWN_CODE: '44',
-			USE_MARKDOWN_DETECTED: '45',
-			USE_MARKDOWN_LINK: '46',
-			USE_MARKDOWN_DICE: '47',
-			USE_MARKDOWN_FORTUNE: '48'
+			USE_MARKDOWN: '35',
 		});
 		const response = await fetch('http://localhost/forms/global/editrole', {
 			headers: {


### PR DESCRIPTION
Prepare for future markdown options and make it more extensible.

Combines stuff like USE_MARKDOWN_PINKTEXT, USE_MARKDOWN_GREENTEXT, etc. all into one USE_MARKDOWN. Makes it easier to later add more styles and not have to rebuild database.