### PR TITLE
Admin capcode will depend on CREATE_BOARD permission instead of ROOT

### DIFF
--- a/lib/post/name.js
+++ b/lib/post/name.js
@@ -11,7 +11,7 @@ module.exports = async (inputName, permissions, boardSettings, boardOwner, board
 	const isBoardOwner = username === boardOwner; //why not just check staffboards and ownedboards?
 	const staffUsernames = Object.keys(boardStaff);
 	const isBoardMod = staffUsernames.includes(username);
-	const staffPermissions = [permissions.get(Permissions.ROOT), permissions.get(Permissions.MANAGE_GLOBAL_GENERAL), isBoardOwner, isBoardMod];
+	const staffPermissions = [permissions.get(Permissions.CREATE_BOARD), permissions.get(Permissions.MANAGE_GLOBAL_GENERAL), isBoardOwner, isBoardMod];
 	const langStaffLevels = staffLevels.map(l => __(l));
 	const staffLevelsRegex = new RegExp(`(${langStaffLevels.join('|')})+`, 'igm');
 


### PR DESCRIPTION
The Admin capcode depended on having ROOT permission, which is unsafe. At anthrochan only Admin can create new board, so the capcode will instead check for CREATE_BOARD permission.