### PR TITLE
Fixed erroneous anthrobooru link, changed glowtext to look nicer, added bluetext and flavour text to home page, added vocaroo embeds (Add vocaroo to your framesrc directive before pulling), updated the faq

### DIFF
--- a/gulp/res/css/style.css
+++ b/gulp/res/css/style.css
@@ -512,9 +512,18 @@ p {
 	color: var(--pinktext-color);
 }
 
+.orangetext {
+	color: #f6750b;
+}
+
+.bluetext {
+	color: #2424ad;
+	font-weight: bold;
+}
+
 .glowtext {
-	color: #008000; /* Darker green */
-    text-shadow: 0 0 10px #006400, 0 0 20px #006400, 0 0 30px #006400;
+	color: black; /* Darker green */
+    text-shadow: 0 0 2px #16ff16,0 0 20px #00f000,0 0 30px #006800;
 }
 
 .embimg {
@@ -1340,6 +1349,11 @@ iframe.captcha, iframe.bypass {
 
 iframe.captcha {
 	/*width: 100%;*/
+}
+
+iframe.vocaroo {
+	display: block;
+	margin-top: 3px;
 }
 
 iframe.embed-video {

--- a/gulp/res/js/embed.js
+++ b/gulp/res/js/embed.js
@@ -50,6 +50,22 @@ if (!isCatalog) { //dont show embed buttons in catalog
 					return null;
 				}
 			},
+			{
+				linkRegex: /^https?:\/\/(?:www\.)?vocaroo\.com\/.+/i,
+							toHtml: (url) => {
+								try {
+									const urlObject = new URL(url);
+									const vocarooId = urlObject.pathname;
+									if (vocarooId) {
+										return [
+											'<iframe class="vocaroo" width="300" height="60" src="" frameborder="0" allow="autoplay"></iframe>',
+											`https://vocaroo.com/embed${vocarooId}`
+										];
+									}
+								} catch (e) { /*invalid url*/ }
+								return null;
+							}
+			},
 			//TODO: add more of these
 		];
 

--- a/lib/post/markdown/markdown.js
+++ b/lib/post/markdown/markdown.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const greentextRegex = /^&gt;((?!&gt;\d+|&gt;&gt;&#x2F;\w+(&#x2F;\d*)?|&gt;&gt;#&#x2F;).*)/gm
-	, pinktextRegex = /^&lt;(.+)/gm
+	, orangetextRegex = /^&lt;(.+)/gm
 	, glowtextRegex = /%%(.+?)%%/gm
 	, boldRegex = /&#39;&#39;(.+?)&#39;&#39;/gm
 	, titleRegex = /&#x3D;&#x3D;(.+?)&#x3D;&#x3D;/gm
+	, bluetextRegex = /--(.+?)--/gm
 	, monoRegex = /&#x60;(.+?)&#x60;/gm
 	, underlineRegex = /__(.+?)__/gm
 	, strikeRegex = /~~(.+?)~~/gm
@@ -33,12 +34,13 @@ let replacements = [];
 const updateMarkdownPerms = () => {
 	replacements = [
 		{ permission: Permissions.USE_MARKDOWN, regex: glowtextRegex, cb: (permissions, match, glowtext) => `<span class='glowtext'>${glowtext}</span>` },
-		{ permission: Permissions.USE_MARKDOWN, regex: pinktextRegex, cb: (permissions, match, pinktext) => `<span class='pinktext'>&lt;${pinktext}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: orangetextRegex, cb: (permissions, match, orangetext) => `<span class='orangetext'>&lt;${orangetext}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: greentextRegex, cb: (permissions, match, greentext) => `<span class='greentext'>&gt;${greentext}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: boldRegex, cb: (permissions, match, bold) => `<span class='bold'>${bold}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: underlineRegex, cb: (permissions, match, underline) => `<span class='underline'>${underline}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: strikeRegex, cb: (permissions, match, strike) => `<span class='strike'>${strike}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: titleRegex, cb: (permissions, match, title) => `<span class='title'>${title}</span>` },
+		{ permission: Permissions.USE_MARKDOWN, regex: bluetextRegex, cb: (permissions, match, bluetext) => `<span class='bluetext'>${bluetext}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: italicRegex, cb: (permissions, match, italic) => `<span class='em'>${italic}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: spoilerRegex, cb: (permissions, match, spoiler) => `<span class='spoiler'>${spoiler}</span>` },
 		{ permission: Permissions.USE_MARKDOWN, regex: monoRegex, cb: (permissions, match, mono) => `<span class='mono'>${mono}</span>` },

--- a/views/custompages/faq.pug
+++ b/views/custompages/faq.pug
@@ -115,39 +115,47 @@ block content
 			tr
 				td &gt;greentext
 				td
-					span.greentext &gt;greentext
+					span.greentext &gt;woah where the hell are we
 			tr
-				td &lt;pinktext
+				td &lt;orangetext
 				td
-					span.pinktext &lt;pinktext
+					span.orangetext &lt;faq.html apparently
+			tr
+				td glowtext
+				td
+					span.glowtext You should kill your neighbour. With a shovel.
 			tr
 				td ==title==
 				td
-					span.title title
+					span.title Red Text!
+			tr
+				td --title--
+				td
+					span.bluetext Blue Text...
 			tr
 				td ''bold''
 				td
-					span.bold bold
+					span.bold bold favours the BRAVE!
 			tr
 				td __underline__
 				td
-					span.underline underline
+					span.underline The west has fallen.
 			tr
 				td ~~strikethrough~~
 				td
-					span.strike strikethrough
+					span.strike Free chicken
 			tr
 				td ||spoiler text||
 				td
-					span.spoiler spoiler text
+					span.spoiler What are you looking at, newfloof?
 			tr
 				td **italic**
 				td
-					span.em italic
+					span.em Italalalalalian
 			tr
 				td (((detected)))
 				td
-					span.detected ((( detected )))
+					span.detected ((( they )))
 			tr
 				td ##2%9+3
 				td
@@ -315,4 +323,4 @@ block content
 				th: a(href='#contact') How can I contact the administration?
 			tr
 				td
-					p Example						
+					p anthrofoo@mailfence.com

--- a/views/pages/home.pug
+++ b/views/pages/home.pug
@@ -19,7 +19,7 @@ block content
 						a(href='/rules.html') rules.
 						br
 						| Affiliated sites:!{' '}
-						a(href='https://anthrobooru.com') Anthrobooru
+						a(href='https://anthrobooru.party') Anthrobooru
 	if recentNews && recentNews.length > 0
 		.table-container.flex-center.mv-10
 			table.newstable


### PR DESCRIPTION
### What this pull request does
What it says on the tin. Before you git pull, you must do ``sudo nano /etc/nginx/snippets/security_headers_nocache.conf`` and add vocaroo to your framesrc to allow it to be embedded. Here's my file:
```
add_header Content-Security-Policy "default-src 'self'; media-src 'self' blob:; img-src 'self' blob:; object-src 'self' blob:; script-src https://smartcaptcha.yandexcloud.net/captcha.js  https://hcaptcha.com https://*.hcaptcha.com  https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/  'self'; style-src https://hcaptcha.com https://*.hcaptcha.com  'self' 'unsafe-inline'; frame-src https://smartcaptcha.yandexcloud.net/  https://hcaptcha.com https://*.hcaptcha.com  https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/  'self' https://www.youtube-nocookie.com/embed/ https://www.bitchute.com/embed/ https://vocaroo.com/embed/ https://odysee.com/%24/embed/; connect-src https://hcaptcha.com https://*.hcaptcha.com  'self' wss://example.com/ wss://www.example.com/; font-src yastatic.net  'self'" always;
add_header Referrer-Policy "same-origin, strict-origin-when-cross-origin" always;
add_header X-Frame-Options "sameorigin" always;
add_header X-Content-Type-Options "nosniff" always;
add_header X-XSS-Protection "1; mode=block" always;
```
## Images
![image](https://github.com/user-attachments/assets/da21b696-3cd6-4e10-accc-6941610b264d)
![image](https://github.com/user-attachments/assets/6a779549-b767-43dc-9470-d3cd93e39203)
