### PR TITLE
Updated glowtext

### DIFF
--- a/gulp/res/css/style.css
+++ b/gulp/res/css/style.css
@@ -522,7 +522,7 @@ p {
 }
 
 .glowtext {
-	color: black; /* Darker green */
+	color: var(--input-color); /*Is always white or black as defined by themes.*/
     text-shadow: 0 0 2px #16ff16,0 0 20px #00f000,0 0 30px #006800;
 }
 


### PR DESCRIPTION
### What this pull request does
- Updated glowtext to use input colour, ensuring that glowtext is black on white backgrounds and white on black backgrounds, preserves the green glow.

This pull req may be updated in the future to include more features but as of right now, if you're reading this, you can go ahead and merge it now.
![image](https://github.com/user-attachments/assets/9c3e3d2e-9b00-4bba-aea4-b126b579cb3f)
![image](https://github.com/user-attachments/assets/3a75a409-d9bb-48f8-b4f2-b09e90adaa0a)
